### PR TITLE
config option to require the monitored path has a specific value

### DIFF
--- a/DeviceHandler.js
+++ b/DeviceHandler.js
@@ -85,9 +85,18 @@ class DeviceHandler {
     }
 
     onMonitorValue(val) {
-        this.skPlugin.debug(`onMonitorValue(${JSON.stringify(val)})`);
+        const isRunning = this.evalRunningValue(val);
+        this.skPlugin.debug(`onMonitorValue(${JSON.stringify(val)}) = ${isRunning}`);
         this.lastValueReceived = this.skPlugin.getTime();
-        this.updateLog(val > 0);
+        this.updateLog(isRunning);
+    }
+
+    evalRunningValue(val) {
+        if (this.config.skMonitorValue) {
+            // note: use abstract equality to ensure ('11' == 11, etc).
+            return (val == this.config.skMonitorValue);
+        }
+        return val > 0;
     }
 
 

--- a/index.js
+++ b/index.js
@@ -10,13 +10,14 @@ class HourMeterPlugin extends SignalKPlugin {
 
     this.optObj({propName: 'devices', title: 'Devices to synthesize hour meters', isArray: true, itemTitle: 'Device'});
     this.optStr({propName: 'name', title: 'Device name', required: true });    
-    this.optStr({propName: 'skMonitorPath', title: 'SignalK value that indicates device is on', required: true  });
+    this.optStr({propName: 'skMonitorPath', title: 'SignalK path that indicates device is on', required: true  });
     this.optInt({propName: 'secTimeout', title: 'SignalK timeout (secs)', defaultVal: 60, longDescription: 'The number of seconds of no SignalK data before device assumed off', required: true});
     this.optInt({propName: 'secResume', title: 'SignalK resume last run (secs)', defaultVal: 300, longDescription: 'Resume tracking previous run if ON detected again within this many seconds', required: true});
     this.optStr({propName: 'skHoursPath', title: 'SignalK path to output hour meter data', longDescription: 'Leave blank to disable'});
     this.optStr({propName: 'skStatusPath', title: 'SignalK path to output device status', longDescription: 'Leave blank to disable'});
     this.optNum({propName: 'offsetHours', title: 'Hours already on device', defaultVal: 0 });
     this.optInt({propName: 'secReportInterval', title: 'Reporting interval (secs)', defaultVal: 30, longDescription: 'Number of seconds between each hour meter/status report', required: true});
+    this.optStr({propName: 'skMonitorValue', title: 'SignalK path value indicating device is running', longDescription: 'Leave blank to allow any value' });
     this.optObjEnd();
 
     this.unsub = [];


### PR DESCRIPTION
This allows for Victron Venus GX digital input pins to be used as a monitor path where there is always a SignalK path, but the value differs based on if the input is on or off.

In the case of the Victron Venus GX digital input number 1, the key is `electrical.venus-input.1.stateNumber`, it's value `11` for Stopped, and `10` for Running.  Alternatively, use `electrical.venus-input.1.state` with value `Running`.